### PR TITLE
feat: export dns-domain-zone-id

### DIFF
--- a/route53-zone.cfndsl.rb
+++ b/route53-zone.cfndsl.rb
@@ -53,6 +53,7 @@ CloudFormation do
   Output('DnsDomainZoneId') do
     Condition 'CreateZone'
     Value(Ref('HostedZone'))
+    Export FnSub("${EnvironmentName}-#{external_parameters[:component_name]}-dns-domain-zone-id")
   end
 
 end


### PR DESCRIPTION
This is used to programatically update r53 record from the ecs container task entrypoint